### PR TITLE
Resolves #8 - optimizing docker tmp dir

### DIFF
--- a/python3.6/gunicorn_conf.py
+++ b/python3.6/gunicorn_conf.py
@@ -28,6 +28,7 @@ workers = web_concurrency
 bind = use_bind
 keepalive = 120
 errorlog = "-"
+worker_tmp_dir = "/dev/shm"
 
 # For debugging and testing
 log_data = {


### PR DESCRIPTION
Heartbeat file for docker should use /dev/shm for the tmp directory - documented here in https://pythonspeed.com/articles/gunicorn-in-docker/