### PR TITLE
enable custom prestart script path with PRE_START_PATH env variable

### DIFF
--- a/python3.6-alpine3.8/start-reload.sh
+++ b/python3.6-alpine3.8/start-reload.sh
@@ -14,8 +14,8 @@ HOST=${HOST:-0.0.0.0}
 PORT=${PORT:-80}
 LOG_LEVEL=${LOG_LEVEL:-info}
 
-# If there's a prestart.sh script in the /app directory, run it before starting
-PRE_START_PATH=/app/prestart.sh
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
 echo "Checking for script in $PRE_START_PATH"
 if [ -f $PRE_START_PATH ] ; then
     echo "Running script $PRE_START_PATH"

--- a/python3.6-alpine3.8/start.sh
+++ b/python3.6-alpine3.8/start.sh
@@ -19,8 +19,8 @@ else
 fi
 export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
 
-# If there's a prestart.sh script in the /app directory, run it before starting
-PRE_START_PATH=/app/prestart.sh
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
 echo "Checking for script in $PRE_START_PATH"
 if [ -f $PRE_START_PATH ] ; then
     echo "Running script $PRE_START_PATH"

--- a/python3.6/start-reload.sh
+++ b/python3.6/start-reload.sh
@@ -14,8 +14,8 @@ HOST=${HOST:-0.0.0.0}
 PORT=${PORT:-80}
 LOG_LEVEL=${LOG_LEVEL:-info}
 
-# If there's a prestart.sh script in the /app directory, run it before starting
-PRE_START_PATH=/app/prestart.sh
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
 echo "Checking for script in $PRE_START_PATH"
 if [ -f $PRE_START_PATH ] ; then
     echo "Running script $PRE_START_PATH"

--- a/python3.6/start.sh
+++ b/python3.6/start.sh
@@ -19,8 +19,8 @@ else
 fi
 export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
 
-# If there's a prestart.sh script in the /app directory, run it before starting
-PRE_START_PATH=/app/prestart.sh
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
 echo "Checking for script in $PRE_START_PATH"
 if [ -f $PRE_START_PATH ] ; then
     echo "Running script $PRE_START_PATH"

--- a/python3.7-alpine3.8/start-reload.sh
+++ b/python3.7-alpine3.8/start-reload.sh
@@ -14,8 +14,8 @@ HOST=${HOST:-0.0.0.0}
 PORT=${PORT:-80}
 LOG_LEVEL=${LOG_LEVEL:-info}
 
-# If there's a prestart.sh script in the /app directory, run it before starting
-PRE_START_PATH=/app/prestart.sh
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
 echo "Checking for script in $PRE_START_PATH"
 if [ -f $PRE_START_PATH ] ; then
     echo "Running script $PRE_START_PATH"

--- a/python3.7-alpine3.8/start.sh
+++ b/python3.7-alpine3.8/start.sh
@@ -19,8 +19,8 @@ else
 fi
 export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
 
-# If there's a prestart.sh script in the /app directory, run it before starting
-PRE_START_PATH=/app/prestart.sh
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
 echo "Checking for script in $PRE_START_PATH"
 if [ -f $PRE_START_PATH ] ; then
     echo "Running script $PRE_START_PATH"

--- a/python3.7/start-reload.sh
+++ b/python3.7/start-reload.sh
@@ -14,8 +14,8 @@ HOST=${HOST:-0.0.0.0}
 PORT=${PORT:-80}
 LOG_LEVEL=${LOG_LEVEL:-info}
 
-# If there's a prestart.sh script in the /app directory, run it before starting
-PRE_START_PATH=/app/prestart.sh
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
 echo "Checking for script in $PRE_START_PATH"
 if [ -f $PRE_START_PATH ] ; then
     echo "Running script $PRE_START_PATH"

--- a/python3.7/start.sh
+++ b/python3.7/start.sh
@@ -19,8 +19,8 @@ else
 fi
 export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
 
-# If there's a prestart.sh script in the /app directory, run it before starting
-PRE_START_PATH=/app/prestart.sh
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
 echo "Checking for script in $PRE_START_PATH"
 if [ -f $PRE_START_PATH ] ; then
     echo "Running script $PRE_START_PATH"


### PR DESCRIPTION
in case your app is not named "app" and you want to run the prestart script, this will come handy

this is backwards compatible (unless someone used PRE_START_PATH variable for something else)