### PR TITLE
Use 'pip --no-cache' and remove '*.pyc' files after installation

### DIFF
--- a/python3.6-alpine3.8/Dockerfile
+++ b/python3.6-alpine3.8/Dockerfile
@@ -3,9 +3,8 @@ FROM python:3.6-alpine3.8
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
-    && pip install --no-cache uvicorn gunicorn \
-    && apk del .build-deps gcc libc-dev make \
-    && find / -xdev -name *.pyc -delete;
+    && pip install --no-cache-dir uvicorn gunicorn \
+    && apk del .build-deps gcc libc-dev make
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/python3.6-alpine3.8/Dockerfile
+++ b/python3.6-alpine3.8/Dockerfile
@@ -3,8 +3,9 @@ FROM python:3.6-alpine3.8
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
-    && pip install uvicorn gunicorn \
-    && apk del .build-deps gcc libc-dev make
+    && pip install --no-cache uvicorn gunicorn \
+    && apk del .build-deps gcc libc-dev make \
+    && find / -xdev -name *.pyc -delete;
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.6
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip install uvicorn gunicorn
+RUN pip --no-cache install uvicorn gunicorn \
+ && find / -xdev -name *.pyc -delete;
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.6
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip --no-cache install uvicorn gunicorn \
- && find / -xdev -name *.pyc -delete;
+RUN pip --no-cache-dir install uvicorn gunicorn
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/python3.7-alpine3.8/Dockerfile
+++ b/python3.7-alpine3.8/Dockerfile
@@ -3,8 +3,9 @@ FROM python:3.7-alpine3.8
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
-    && pip install uvicorn gunicorn \
-    && apk del .build-deps gcc libc-dev make
+    && pip install --no-cache uvicorn gunicorn \
+    && apk del .build-deps gcc libc-dev make \
+    && find / -xdev -name *.pyc -delete;
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/python3.7-alpine3.8/Dockerfile
+++ b/python3.7-alpine3.8/Dockerfile
@@ -3,9 +3,8 @@ FROM python:3.7-alpine3.8
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
-    && pip install --no-cache uvicorn gunicorn \
-    && apk del .build-deps gcc libc-dev make \
-    && find / -xdev -name *.pyc -delete;
+    && pip install --no-cache-dir uvicorn gunicorn \
+    && apk del .build-deps gcc libc-dev make
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.7
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip install uvicorn gunicorn
+RUN pip --no-cache install uvicorn gunicorn \
+ && find / -xdev -name *.pyc -delete;
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.7
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip --no-cache install uvicorn gunicorn \
- && find / -xdev -name *.pyc -delete;
+RUN pip --no-cache-dir install uvicorn gunicorn
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh


### PR DESCRIPTION
With the proposed patch the size of the images get reduced by ~15MB each, which for the alpine-based images translates into more than 10% of the total size.

If you want I can make a Pull Request for  `uvicorn-gunicorn-fastapi-docker`, too