### PR TITLE
:heavy_plus_sign: Add Python 3.8 with Alpine 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-dist: bionic
+dist: xenial
 
 language: python
 
 python:
-  - "3.8"
+  - "3.7"
 
 install:
-  - pip install docker pytest
+  - pip install docker==4.1.0 pytest
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-dist: xenial
+dist: bionic
 
 language: python
 
 python:
-  - "3.7"
+  - "3.8"
 
 install:
   - pip install docker pytest
@@ -13,8 +13,10 @@ services:
 
 env:
   - NAME='latest' BUILD_PATH='python3.7' TEST_STR1='Hello world! From Uvicorn with Gunicorn. Using Python 3.7' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.7'
+  - NAME='python3.8' BUILD_PATH='python3.8' TEST_STR1='Hello world! From Uvicorn with Gunicorn. Using Python 3.8' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.8'
   - NAME='python3.7' BUILD_PATH='python3.7' TEST_STR1='Hello world! From Uvicorn with Gunicorn. Using Python 3.7' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.6' BUILD_PATH='python3.6' TEST_STR1='Hello world! From Uvicorn with Gunicorn. Using Python 3.6' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.6'
+  - NAME='python3.8-alpine3.10' BUILD_PATH='python3.8-alpine3.10' TEST_STR1='Hello world! From Uvicorn with Gunicorn in Alpine. Using Python 3.8' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.8'
   - NAME='python3.7-alpine3.8' BUILD_PATH='python3.7-alpine3.8' TEST_STR1='Hello world! From Uvicorn with Gunicorn in Alpine. Using Python 3.7' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.6-alpine3.8' BUILD_PATH='python3.6-alpine3.8' TEST_STR1='Hello world! From Uvicorn with Gunicorn in Alpine. Using Python 3.6' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.6'
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.7"
 
 install:
-  - pip install docker==4.1.0 pytest
+  - pip install docker pytest
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 ## Supported tags and respective `Dockerfile` links
 
+* [`python3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/python3.8/Dockerfile)
 * [`python3.7`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/python3.7/Dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/python3.6/Dockerfile)
 * [`python3.6-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/python3.6-alpine3.8/Dockerfile)
 * [`python3.7-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/python3.7-alpine3.8/Dockerfile)
+* [`python3.8-alpine3.10` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/python3.8-alpine3.10/Dockerfile)
 
 **Note**: Note: There are [tags for each build date](https://hub.docker.com/r/tiangolo/uvicorn-gunicorn/tags). If you need to "pin" the Docker image version you use, you can select one of those tags. E.g. `tiangolo/uvicorn-gunicorn:python3.7-2019-10-15`.
 
 # uvicorn-gunicorn
 
-[**Docker**](https://www.docker.com/) image with [**Uvicorn**](https://www.uvicorn.org/) managed by [**Gunicorn**](https://gunicorn.org/) for high-performance web applications in **[Python](https://www.python.org/) 3.7** and **3.6** with performance auto-tuning. Optionally with Alpine Linux.
+[**Docker**](https://www.docker.com/) image with [**Uvicorn**](https://www.uvicorn.org/) managed by [**Gunicorn**](https://gunicorn.org/) for high-performance web applications in **[Python](https://www.python.org/) 3.8**, **3.7** and **3.6** with performance auto-tuning. Optionally with Alpine Linux.
 
 **GitHub repo**: [https://github.com/tiangolo/uvicorn-gunicorn-docker](https://github.com/tiangolo/uvicorn-gunicorn-docker)
 

--- a/python3.8-alpine3.10/Dockerfile
+++ b/python3.8-alpine3.10/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.8-alpine3.10
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
+    && pip install uvicorn gunicorn \
+    && apk del .build-deps gcc libc-dev make
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]

--- a/python3.8-alpine3.10/Dockerfile
+++ b/python3.8-alpine3.10/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine3.10
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
-    && pip install uvicorn gunicorn \
+    && pip install --no-cache-dir uvicorn gunicorn \
     && apk del .build-deps gcc libc-dev make
 
 COPY ./start.sh /start.sh

--- a/python3.8-alpine3.10/app/main.py
+++ b/python3.8-alpine3.10/app/main.py
@@ -1,0 +1,24 @@
+import sys
+
+
+class App:
+    def __init__(self, scope):
+        assert scope["type"] == "http"
+        self.scope = scope
+
+    async def __call__(self, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/plain"]],
+            }
+        )
+        version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        message = f"Hello world! From Uvicorn with Gunicorn in Alpine. Using Python {version}".encode(
+            "utf-8"
+        )
+        await send({"type": "http.response.body", "body": message})
+
+
+app = App

--- a/python3.8-alpine3.10/app/prestart.sh
+++ b/python3.8-alpine3.10/app/prestart.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env sh
+
+echo "Running inside /app/prestart.sh, you could add migrations to this file, e.g.:"
+
+echo "
+#! /usr/bin/env bash
+
+# Let the DB start
+sleep 10;
+# Run migrations
+alembic upgrade head
+"

--- a/python3.8-alpine3.10/gunicorn_conf.py
+++ b/python3.8-alpine3.10/gunicorn_conf.py
@@ -1,0 +1,42 @@
+import json
+import multiprocessing
+import os
+
+workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
+web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
+host = os.getenv("HOST", "0.0.0.0")
+port = os.getenv("PORT", "80")
+bind_env = os.getenv("BIND", None)
+use_loglevel = os.getenv("LOG_LEVEL", "info")
+if bind_env:
+    use_bind = bind_env
+else:
+    use_bind = f"{host}:{port}"
+
+cores = multiprocessing.cpu_count()
+workers_per_core = float(workers_per_core_str)
+default_web_concurrency = workers_per_core * cores
+if web_concurrency_str:
+    web_concurrency = int(web_concurrency_str)
+    assert web_concurrency > 0
+else:
+    web_concurrency = max(int(default_web_concurrency), 2)
+
+# Gunicorn config variables
+loglevel = use_loglevel
+workers = web_concurrency
+bind = use_bind
+keepalive = 120
+errorlog = "-"
+
+# For debugging and testing
+log_data = {
+    "loglevel": loglevel,
+    "workers": workers,
+    "bind": bind,
+    # Additional, non-gunicorn variables
+    "workers_per_core": workers_per_core,
+    "host": host,
+    "port": port,
+}
+print(json.dumps(log_data))

--- a/python3.8-alpine3.10/start-reload.sh
+++ b/python3.8-alpine3.10/start-reload.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-80}
+LOG_LEVEL=${LOG_LEVEL:-info}
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Uvicorn with live reload
+exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE"

--- a/python3.8-alpine3.10/start.sh
+++ b/python3.8-alpine3.10/start.sh
@@ -1,0 +1,33 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+if [ -f /app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/gunicorn_conf.py
+elif [ -f /app/app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/app/gunicorn_conf.py
+else
+    DEFAULT_GUNICORN_CONF=/gunicorn_conf.py
+fi
+export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Gunicorn
+exec gunicorn -k uvicorn.workers.UvicornWorker -c "$GUNICORN_CONF" "$APP_MODULE"

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.8
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN pip install uvicorn gunicorn
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip install uvicorn gunicorn
+RUN pip install --no-cache-dir uvicorn gunicorn
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/python3.8/app/main.py
+++ b/python3.8/app/main.py
@@ -1,0 +1,24 @@
+import sys
+
+
+class App:
+    def __init__(self, scope):
+        assert scope["type"] == "http"
+        self.scope = scope
+
+    async def __call__(self, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/plain"]],
+            }
+        )
+        version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        message = f"Hello world! From Uvicorn with Gunicorn. Using Python {version}".encode(
+            "utf-8"
+        )
+        await send({"type": "http.response.body", "body": message})
+
+
+app = App

--- a/python3.8/app/prestart.sh
+++ b/python3.8/app/prestart.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env sh
+
+echo "Running inside /app/prestart.sh, you could add migrations to this file, e.g.:"
+
+echo "
+#! /usr/bin/env bash
+
+# Let the DB start
+sleep 10;
+# Run migrations
+alembic upgrade head
+"

--- a/python3.8/gunicorn_conf.py
+++ b/python3.8/gunicorn_conf.py
@@ -1,0 +1,42 @@
+import json
+import multiprocessing
+import os
+
+workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
+web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
+host = os.getenv("HOST", "0.0.0.0")
+port = os.getenv("PORT", "80")
+bind_env = os.getenv("BIND", None)
+use_loglevel = os.getenv("LOG_LEVEL", "info")
+if bind_env:
+    use_bind = bind_env
+else:
+    use_bind = f"{host}:{port}"
+
+cores = multiprocessing.cpu_count()
+workers_per_core = float(workers_per_core_str)
+default_web_concurrency = workers_per_core * cores
+if web_concurrency_str:
+    web_concurrency = int(web_concurrency_str)
+    assert web_concurrency > 0
+else:
+    web_concurrency = max(int(default_web_concurrency), 2)
+
+# Gunicorn config variables
+loglevel = use_loglevel
+workers = web_concurrency
+bind = use_bind
+keepalive = 120
+errorlog = "-"
+
+# For debugging and testing
+log_data = {
+    "loglevel": loglevel,
+    "workers": workers,
+    "bind": bind,
+    # Additional, non-gunicorn variables
+    "workers_per_core": workers_per_core,
+    "host": host,
+    "port": port,
+}
+print(json.dumps(log_data))

--- a/python3.8/start-reload.sh
+++ b/python3.8/start-reload.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-80}
+LOG_LEVEL=${LOG_LEVEL:-info}
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Uvicorn with live reload
+exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE"

--- a/python3.8/start.sh
+++ b/python3.8/start.sh
@@ -1,0 +1,33 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+if [ -f /app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/gunicorn_conf.py
+elif [ -f /app/app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/app/gunicorn_conf.py
+else
+    DEFAULT_GUNICORN_CONF=/gunicorn_conf.py
+fi
+export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Gunicorn
+exec gunicorn -k uvicorn.workers.UvicornWorker -c "$GUNICORN_CONF" "$APP_MODULE"

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -10,6 +10,12 @@ environments = [
         "TEST_STR2": "Test app. From Uvicorn with Gunicorn. Using Python 3.7",
     },
     {
+        "NAME": "python3.8",
+        "BUILD_PATH": "python3.8",
+        "TEST_STR1": "Hello world! From Uvicorn with Gunicorn. Using Python 3.8",
+        "TEST_STR2": "Test app. From Uvicorn with Gunicorn. Using Python 3.8",
+    },
+    {
         "NAME": "python3.7",
         "BUILD_PATH": "python3.7",
         "TEST_STR1": "Hello world! From Uvicorn with Gunicorn. Using Python 3.7",
@@ -20,6 +26,12 @@ environments = [
         "BUILD_PATH": "python3.6",
         "TEST_STR1": "Hello world! From Uvicorn with Gunicorn. Using Python 3.6",
         "TEST_STR2": "Test app. From Uvicorn with Gunicorn. Using Python 3.6",
+    },
+    {
+        "NAME": "python3.8-alpine3.10",
+        "BUILD_PATH": "python3.8-alpine3.10",
+        "TEST_STR1": "Hello world! From Uvicorn with Gunicorn in Alpine. Using Python 3.8",
+        "TEST_STR2": "Test app. From Uvicorn with Gunicorn. Using Python 3.8",
     },
     {
         "NAME": "python3.7-alpine3.8",

--- a/tests/test_02_app/custom_app/python3.8-alpine3.10.dockerfile
+++ b/tests/test_02_app/custom_app/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_02_app/custom_app/python3.8.dockerfile
+++ b/tests/test_02_app/custom_app/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app

--- a/tests/test_02_app/package_app/python3.8-alpine3.10.dockerfile
+++ b/tests/test_02_app/package_app/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_02_app/package_app/python3.8.dockerfile
+++ b/tests/test_02_app/package_app/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_config/python3.8-alpine3.10.dockerfile
+++ b/tests/test_02_app/package_app_config/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_config/python3.8.dockerfile
+++ b/tests/test_02_app/package_app_config/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_custom_config/python3.8-alpine3.10.dockerfile
+++ b/tests/test_02_app/package_app_custom_config/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_custom_config/python3.8.dockerfile
+++ b/tests/test_02_app/package_app_custom_config/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_sub_config/python3.8-alpine3.10.dockerfile
+++ b/tests/test_02_app/package_app_sub_config/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_sub_config/python3.8.dockerfile
+++ b/tests/test_02_app/package_app_sub_config/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app

--- a/tests/test_02_app/simple_app/python3.8-alpine3.10.dockerfile
+++ b/tests/test_02_app/simple_app/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_02_app/simple_app/python3.8.dockerfile
+++ b/tests/test_02_app/simple_app/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app

--- a/tests/test_04_app_reload/custom_app/python3.8-alpine3.10.dockerfile
+++ b/tests/test_04_app_reload/custom_app/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_04_app_reload/custom_app/python3.8.dockerfile
+++ b/tests/test_04_app_reload/custom_app/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app

--- a/tests/test_04_app_reload/package_app/python3.8-alpine3.10.dockerfile
+++ b/tests/test_04_app_reload/package_app/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_04_app_reload/package_app/python3.8.dockerfile
+++ b/tests/test_04_app_reload/package_app/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app

--- a/tests/test_04_app_reload/simple_app/python3.8-alpine3.10.dockerfile
+++ b/tests/test_04_app_reload/simple_app/python3.8-alpine3.10.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+COPY ./app /app

--- a/tests/test_04_app_reload/simple_app/python3.8.dockerfile
+++ b/tests/test_04_app_reload/simple_app/python3.8.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+COPY ./app /app


### PR DESCRIPTION
This PR provides containers `tiangolo/uvicorn-gunicorn:python3.8` and `tiangolo/uvicorn-gunicorn:python3.8-alpine3.10`.

As mentioned in https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/pull/18#issuecomment-543033165 at the moment it should not be merged, because `uvloop` does not compile in Python 3.8 yet. When that library and other dependencies are solved, then this PR could be merged safely.

Summary:
- Does NOT modify `latest` tag
- Does NOT change previous Dockerfile's Alpine version
- Provides Python 3.8 containers
- README still points to 3.7 as example