### PR TITLE
Support for custom gunicorn workers

### DIFF
--- a/python3.7/start.sh
+++ b/python3.7/start.sh
@@ -18,6 +18,7 @@ else
     DEFAULT_GUNICORN_CONF=/gunicorn_conf.py
 fi
 export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
+export GUNICORN_WORKER=${GUNICORN_WORKER:-uvicorn.workers.UvicornWorker}
 
 # If there's a prestart.sh script in the /app directory, run it before starting
 PRE_START_PATH=/app/prestart.sh
@@ -30,4 +31,4 @@ else
 fi
 
 # Start Gunicorn
-exec gunicorn -k uvicorn.workers.UvicornWorker -c "$GUNICORN_CONF" "$APP_MODULE"
+exec gunicorn -k "$GUNICORN_WORKER" -c "$GUNICORN_CONF" "$APP_MODULE"


### PR DESCRIPTION
This PR should make it is easy to use `uvicorn.workers.UvicornH11Worker` or any other custom worker for that matter while still keeping backwards compatibility.