### PR TITLE
Added env vars for timeout, graceful timeout, and keepalive in gunicorn config

### DIFF
--- a/python3.7/gunicorn_conf.py
+++ b/python3.7/gunicorn_conf.py
@@ -4,6 +4,9 @@ import os
 
 workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
 web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
+graceful_timeout_str = os.getenv("GRACEFUL_TIMEOUT", "120")
+timeout_str = os.getenv("TIMEOUT", "120")
+keepalive_str = os.getenv("KEEPALIVE", "120")
 host = os.getenv("HOST", "0.0.0.0")
 port = os.getenv("PORT", "80")
 bind_env = os.getenv("BIND", None)
@@ -22,11 +25,14 @@ if web_concurrency_str:
 else:
     web_concurrency = max(int(default_web_concurrency), 2)
 
+graceful_timeout = int(graceful_timeout_str)
+timeout = int(timeout_str)
+keepalive = int(keepalive_str)
+
 # Gunicorn config variables
 loglevel = use_loglevel
 workers = web_concurrency
 bind = use_bind
-keepalive = 120
 errorlog = "-"
 
 # For debugging and testing


### PR DESCRIPTION
I've added the following **optional environment variables** as a means to externalize these config options from `gunicorn_conf.py`:

```
GRACEFUL_TIMEOUT
TIMEOUT
KEEPALIVE
```

We need these because we are using this image internally and we have some long hanging POST requests.
