### PR TITLE
Add python3.7-slim image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - NAME='latest' BUILD_PATH='python3.7' TEST_STR1='Hello world! From Uvicorn with Gunicorn. Using Python 3.7' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.7' BUILD_PATH='python3.7' TEST_STR1='Hello world! From Uvicorn with Gunicorn. Using Python 3.7' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.6' BUILD_PATH='python3.6' TEST_STR1='Hello world! From Uvicorn with Gunicorn. Using Python 3.6' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.6'
+  - NAME='python3.7-slim' BUILD_PATH='python3.7-slim' TEST_STR1='Hello world! From Uvicorn with Gunicorn. Using Python 3.7' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.7-alpine3.8' BUILD_PATH='python3.7-alpine3.8' TEST_STR1='Hello world! From Uvicorn with Gunicorn in Alpine. Using Python 3.7' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.6-alpine3.8' BUILD_PATH='python3.6-alpine3.8' TEST_STR1='Hello world! From Uvicorn with Gunicorn in Alpine. Using Python 3.6' TEST_STR2='Test app. From Uvicorn with Gunicorn. Using Python 3.6'
   

--- a/python3.7-slim/Dockerfile
+++ b/python3.7-slim/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.7-slim
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN apt-get update && apt-get install -y gcc
+
+RUN pip install uvicorn gunicorn
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]

--- a/python3.7-slim/app/main.py
+++ b/python3.7-slim/app/main.py
@@ -1,0 +1,24 @@
+import sys
+
+
+class App:
+    def __init__(self, scope):
+        assert scope["type"] == "http"
+        self.scope = scope
+
+    async def __call__(self, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/plain"]],
+            }
+        )
+        version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        message = f"Hello world! From Uvicorn with Gunicorn. Using Python {version}".encode(
+            "utf-8"
+        )
+        await send({"type": "http.response.body", "body": message})
+
+
+app = App

--- a/python3.7-slim/app/prestart.sh
+++ b/python3.7-slim/app/prestart.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env sh
+
+echo "Running inside /app/prestart.sh, you could add migrations to this file, e.g.:"
+
+echo "
+#! /usr/bin/env bash
+
+# Let the DB start
+sleep 10;
+# Run migrations
+alembic upgrade head
+"

--- a/python3.7-slim/gunicorn_conf.py
+++ b/python3.7-slim/gunicorn_conf.py
@@ -1,0 +1,42 @@
+import json
+import multiprocessing
+import os
+
+workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
+web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
+host = os.getenv("HOST", "0.0.0.0")
+port = os.getenv("PORT", "80")
+bind_env = os.getenv("BIND", None)
+use_loglevel = os.getenv("LOG_LEVEL", "info")
+if bind_env:
+    use_bind = bind_env
+else:
+    use_bind = f"{host}:{port}"
+
+cores = multiprocessing.cpu_count()
+workers_per_core = float(workers_per_core_str)
+default_web_concurrency = workers_per_core * cores
+if web_concurrency_str:
+    web_concurrency = int(web_concurrency_str)
+    assert web_concurrency > 0
+else:
+    web_concurrency = max(int(default_web_concurrency), 2)
+
+# Gunicorn config variables
+loglevel = use_loglevel
+workers = web_concurrency
+bind = use_bind
+keepalive = 120
+errorlog = "-"
+
+# For debugging and testing
+log_data = {
+    "loglevel": loglevel,
+    "workers": workers,
+    "bind": bind,
+    # Additional, non-gunicorn variables
+    "workers_per_core": workers_per_core,
+    "host": host,
+    "port": port,
+}
+print(json.dumps(log_data))

--- a/python3.7-slim/start-reload.sh
+++ b/python3.7-slim/start-reload.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-80}
+LOG_LEVEL=${LOG_LEVEL:-info}
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Uvicorn with live reload
+exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE"

--- a/python3.7-slim/start.sh
+++ b/python3.7-slim/start.sh
@@ -1,0 +1,33 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+if [ -f /app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/gunicorn_conf.py
+elif [ -f /app/app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/app/gunicorn_conf.py
+else
+    DEFAULT_GUNICORN_CONF=/gunicorn_conf.py
+fi
+export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Gunicorn
+exec gunicorn -k uvicorn.workers.UvicornWorker -c "$GUNICORN_CONF" "$APP_MODULE"

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -16,6 +16,12 @@ environments = [
         "TEST_STR2": "Test app. From Uvicorn with Gunicorn. Using Python 3.7",
     },
     {
+        "NAME": "python3.7-slim",
+        "BUILD_PATH": "python3.7-slim",
+        "TEST_STR1": "Hello world! From Uvicorn with Gunicorn. Using Python 3.7-slim",
+        "TEST_STR2": "Test app. From Uvicorn with Gunicorn. Using Python 3.7-slim",
+    },
+    {
         "NAME": "python3.6",
         "BUILD_PATH": "python3.6",
         "TEST_STR1": "Hello world! From Uvicorn with Gunicorn. Using Python 3.6",

--- a/tests/test_02_app/custom_app/python3.7-slim.dockerfile
+++ b/tests/test_02_app/custom_app/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app

--- a/tests/test_02_app/package_app/python3.7-slim.dockerfile
+++ b/tests/test_02_app/package_app/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_config/python3.7-slim.dockerfile
+++ b/tests/test_02_app/package_app_config/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_custom_config/python3.7-slim.dockerfile
+++ b/tests/test_02_app/package_app_custom_config/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app

--- a/tests/test_02_app/package_app_sub_config/python3.7-slim.dockerfile
+++ b/tests/test_02_app/package_app_sub_config/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app

--- a/tests/test_02_app/simple_app/python3.7-slim.dockerfile
+++ b/tests/test_02_app/simple_app/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app

--- a/tests/test_04_app_reload/custom_app/python3.7-slim.dockerfile
+++ b/tests/test_04_app_reload/custom_app/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app

--- a/tests/test_04_app_reload/package_app/python3.7-slim.dockerfile
+++ b/tests/test_04_app_reload/package_app/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app

--- a/tests/test_04_app_reload/simple_app/python3.7-slim.dockerfile
+++ b/tests/test_04_app_reload/simple_app/python3.7-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+COPY ./app /app


### PR DESCRIPTION
This PR adds a variant of the image based on `python:3.7-slim` instead of `python3.7`.
The resulting image is much smaller, 342MB instead 949MB for the default one.

I had to add `gcc` to the `slim` image to be able to install some of the python dependencies. I decided to leave it on the resulting image, as it's likely other python packages will need it as well.

This PR fixes #16 