### PR TITLE
Iterate over Gunicorn processes with filter to avoid test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
+*env/
 build/
 develop-eggs/
 dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uvicorn-gunicorn-docker"
-version = "0.1.0"
+version = "0.6.0"
 description = "Docker image with Uvicorn managed by Gunicorn for high-performance web applications in Python 3.7 and 3.6 with performance auto-tuning. Optionally with Alpine Linux."
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Description

tests/utils.py `get_process_names()` gets a list of Gunicorn processes. The list is then used by downstream tests to locate gunicorn_conf.py and verify the correct number of Gunicorn processes. `top()["Processes"]` returns a list of lists, with Gunicorn process names inside each list.

The index of the process name was hard-coded into `get_process_names()`:

```py
def get_process_names(container: Container) -> List[str]:
    top = container.top()
    process_commands = [p[7] for p in top["Processes"]]
    gunicorn_processes = [p for p in process_commands if "gunicorn" in p]
    return gunicorn_processes

```

This was causing test failures for me on my local machine, because the process names were in a different position (`p[3]` instead of `p[7]`).

```py
{
    "Processes": [
        [
            "29173",
            "root",
            "0:00",
            "{gunicorn} /usr/local/bin/python /usr/local/bin/gunicorn -k uvicorn.workers.UvicornWorker -c /gunicorn_conf.py main:app",
        ],
        [
            "29207",
            "root",
            "0:00",
            "{gunicorn} /usr/local/bin/python /usr/local/bin/gunicorn -k uvicorn.workers.UvicornWorker -c /gunicorn_conf.py main:app",
        ],
        [
            "29208",
            "root",
            "0:00",
            "{gunicorn} /usr/local/bin/python /usr/local/bin/gunicorn -k uvicorn.workers.UvicornWorker -c /gunicorn_conf.py main:app",
        ],
    ],
    "Titles": ["PID", "USER", "TIME", "COMMAND"],
}
```

## Changes

:recycle: A concise solution is to return an iterator with `filter()` instead:

```py
def get_process_names(container: Container) -> List[Iterator[Any]]:
    return [filter(lambda i: "gunicorn" in i, p) for p in container.top()["Processes"]]

```

The iterator items are retrieved later by `get_gunicorn_conf_path()`.

I took care of a couple of Poetry chores also:

- :wrench: Update Poetry version to current release (4d541ad)
- :wrench: Ignore local Poetry virtualenvs (f2a269e)
  - venv/ used by venv
  - .venv/ used for [local Poetry virtualenvs](https://python-poetry.org/docs/configuration/)
