### PR TITLE
Create python3.8-alpine3.12.dockerfile

### DIFF
--- a/docker-images/python3.8-alpine3.12.dockerfile
+++ b/docker-images/python3.8-alpine3.12.dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.8-alpine3.12
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
+    && pip install --no-cache-dir "uvicorn[standard]" gunicorn \
+    && apk del .build-deps gcc libc-dev make
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]


### PR DESCRIPTION
Installing cryptography in alpine 3.10 fails. It needs at least Alpine 3.12 to be able to match the rust extension requirement >=1.41.0

