### PR TITLE
Bump uvicorn to >=0.11.7

### DIFF
--- a/docker-images/python3.6-alpine3.8.dockerfile
+++ b/docker-images/python3.6-alpine3.8.dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-alpine3.8
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
-    && pip install --no-cache-dir "uvicorn[standard]" gunicorn \
+    && pip install --no-cache-dir "uvicorn[standard]>=0.11.7" gunicorn \
     && apk del .build-deps gcc libc-dev make
 
 COPY ./start.sh /start.sh

--- a/docker-images/python3.6.dockerfile
+++ b/docker-images/python3.6.dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip install --no-cache-dir "uvicorn[standard]" gunicorn
+RUN pip install --no-cache-dir "uvicorn[standard]>=0.11.7" gunicorn
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/docker-images/python3.7-alpine3.8.dockerfile
+++ b/docker-images/python3.7-alpine3.8.dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-alpine3.8
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
-    && pip install --no-cache-dir "uvicorn[standard]" gunicorn \
+    && pip install --no-cache-dir "uvicorn[standard]>=0.11.7" gunicorn \
     && apk del .build-deps gcc libc-dev make
 
 COPY ./start.sh /start.sh

--- a/docker-images/python3.7.dockerfile
+++ b/docker-images/python3.7.dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip install --no-cache-dir "uvicorn[standard]" gunicorn
+RUN pip install --no-cache-dir "uvicorn[standard]>=0.11.7" gunicorn
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/docker-images/python3.8-alpine3.10.dockerfile
+++ b/docker-images/python3.8-alpine3.10.dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine3.10
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
-    && pip install --no-cache-dir "uvicorn[standard]" gunicorn \
+    && pip install --no-cache-dir "uvicorn[standard]>=0.11.7" gunicorn \
     && apk del .build-deps gcc libc-dev make
 
 COPY ./start.sh /start.sh

--- a/docker-images/python3.8-slim.dockerfile
+++ b/docker-images/python3.8-slim.dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8-slim
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip install --no-cache-dir "uvicorn[standard]" gunicorn
+RUN pip install --no-cache-dir "uvicorn[standard]>=0.11.7" gunicorn
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/docker-images/python3.8.dockerfile
+++ b/docker-images/python3.8.dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-RUN pip install --no-cache-dir "uvicorn[standard]" gunicorn
+RUN pip install --no-cache-dir "uvicorn[standard]>=0.11.7" gunicorn
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh


### PR DESCRIPTION
Closes https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/issues/85

I suppose it would be more maintainable to somehow have this dependencies managed by poetry and let dependabot deal with them.

Not sure how to do that for this (nice) build and test infrastructure you have here.