### PR TITLE
Update source of poetry installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Then you could have a `Dockerfile` like:
 FROM tiangolo/uvicorn-gunicorn:python3.7
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
As of the latest poetry release (1.1.7) `get-poetry` is no longer the recommended installation script, and in the next minor release it will be fully replaced by `install-poetry` 🙂 
