### PR TITLE
Build containers for multiple architectures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,11 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: "3.7"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
       - name: Install Dependencies
         run: python3.7 -m pip install docker pytest
       - name: Deploy Image

--- a/docker-images/python3.8-slim.dockerfile
+++ b/docker-images/python3.8-slim.dockerfile
@@ -8,7 +8,7 @@ FROM python:3.8-slim
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-COPY --from=0 /usr/local/lib/python3.9 /usr/local/lib/python3.9
+COPY --from=0 /usr/local/lib/python3.8 /usr/local/lib/python3.8
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/docker-images/python3.8-slim.dockerfile
+++ b/docker-images/python3.8-slim.dockerfile
@@ -1,4 +1,4 @@
-from python:3.8
+FROM python:3.8
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt

--- a/docker-images/python3.8-slim.dockerfile
+++ b/docker-images/python3.8-slim.dockerfile
@@ -1,9 +1,14 @@
+from python:3.8
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+
 FROM python:3.8-slim
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY --from=0 /usr/local/lib/python3.9 /usr/local/lib/python3.9
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/docker-images/python3.9-slim.dockerfile
+++ b/docker-images/python3.9-slim.dockerfile
@@ -1,9 +1,14 @@
+from python:3.9
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+
 FROM python:3.9-slim
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY --from=0 /usr/local/lib/python3.9 /usr/local/lib/python3.9
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/docker-images/python3.9-slim.dockerfile
+++ b/docker-images/python3.9-slim.dockerfile
@@ -1,4 +1,4 @@
-from python:3.9
+FROM python:3.9
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -8,13 +8,6 @@ if [ "$NAME" == "latest" ] ; then
     DOCKERFILE="python3.9"
 fi
 
-# Slim images are missing the build tools for uvloop
-if [[ "$NAME" =~ "slim" ]] ; then
-    PLATFORMS="linux/amd64"
-else
-    PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
-fi
-
 use_tag="tiangolo/uvicorn-gunicorn:$NAME"
 use_dated_tag="${use_tag}-$(date -I)"
 
@@ -23,7 +16,7 @@ bash scripts/docker-login.sh
 docker buildx create --use
 
 docker buildx build \
-  --platform $PLATFORMS \
+  --platform "linux/amd64,linux/arm64,linux/arm/v7" \
   --file "./docker-images/${DOCKERFILE}.dockerfile" \
   -t "$use_tag"  \
   -t "$use_dated_tag"  \

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -8,6 +8,13 @@ if [ "$NAME" == "latest" ] ; then
     DOCKERFILE="python3.9"
 fi
 
+# Slim images are missing the build tools for uvloop
+if [[ "$NAME" =~ "slim" ]] ; then
+    PLATFORMS="linux/amd64"
+else
+    PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
+fi
+
 use_tag="tiangolo/uvicorn-gunicorn:$NAME"
 use_dated_tag="${use_tag}-$(date -I)"
 
@@ -16,7 +23,7 @@ bash scripts/docker-login.sh
 docker buildx create --use
 
 docker buildx build \
-  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+  --platform $PLATFORMS \
   --file "./docker-images/${DOCKERFILE}.dockerfile" \
   -t "$use_tag"  \
   -t "$use_dated_tag"  \

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -13,7 +13,7 @@ use_dated_tag="${use_tag}-$(date -I)"
 
 bash scripts/docker-login.sh
 
-docker buildx create --use
+docker buildx use multiarch ||  docker buildx create --name multiarch --use
 
 docker buildx build \
   --platform "linux/amd64,linux/arm64,linux/arm/v7" \

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -2,14 +2,23 @@
 
 set -e
 
+DOCKERFILE="$NAME"
+
+if [ "$NAME" == "latest" ] ; then
+    DOCKERFILE="python3.9"
+fi
+
 use_tag="tiangolo/uvicorn-gunicorn:$NAME"
 use_dated_tag="${use_tag}-$(date -I)"
 
-bash scripts/build.sh
-
-docker tag "$use_tag" "$use_dated_tag"
-
 bash scripts/docker-login.sh
 
-docker push "$use_tag"
-docker push "$use_dated_tag"
+docker buildx create --use
+
+docker buildx build \
+  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+  --file "./docker-images/${DOCKERFILE}.dockerfile" \
+  -t "$use_tag"  \
+  -t "$use_dated_tag"  \
+  --push \
+  "./docker-images/"


### PR DESCRIPTION
This switches the build+push to using buildx, which in turn is building for amd64, arm64, and arm v7. This shouldn't change the amd64 containers in any way, but will allow users running on OSX M1 chips or AWS Graviton to use native containers instead of the qemu bridge (which segfaults a lot on the new m1 chips).

Once merged I'll make a PR to the FastAPI containers as well, but that requires these containers already be published.