### PR TITLE
Bump to Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-* [`python3.9`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.9.dockerfile)
+* [`python3.10`, `latest` (Docerfile)](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.10.dockerfile)
+* [`python3.9`,_(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.9.dockerfile)
 * [`python3.8`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.8.dockerfile)
 * [`python3.7`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.7.dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.6.dockerfile)
+* [`python3.10-slim`, (Docerfile)](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.10-slim.dockerfile)
 * [`python3.9-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.9-slim.dockerfile)
 * [`python3.8-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.8-slim.dockerfile)
+* [`python3.10-alpine3.14` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.10-alpine3.14.dockerfile)
 * [`python3.9-alpine3.14` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.9-alpine3.14.dockerfile)
 * [`python3.8-alpine3.10` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.8-alpine3.10.dockerfile)
 * [`python3.7-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.7-alpine3.8.dockerfile)

--- a/docker-images/python3.10-alpine3.14.dockerfile
+++ b/docker-images/python3.10-alpine3.14.dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.10-alpine3.14
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY requirements.txt /tmp/requirements.txt
+RUN apk add --no-cache --virtual .build-deps gcc libc-dev make \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && apk del .build-deps gcc libc-dev make
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]

--- a/docker-images/python3.10-slim.dockerfile
+++ b/docker-images/python3.10-slim.dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.10-slim
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]

--- a/docker-images/python3.10.dockerfile
+++ b/docker-images/python3.10.dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.10
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ use_tag="tiangolo/uvicorn-gunicorn:$NAME"
 DOCKERFILE="$NAME"
 
 if [ "$NAME" == "latest" ] ; then
-    DOCKERFILE="python3.9"
+    DOCKERFILE="python3.10"
 fi
 
 docker build -t "$use_tag" --file "./docker-images/${DOCKERFILE}.dockerfile" "./docker-images/"

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -3,13 +3,16 @@ import subprocess
 import sys
 
 environments = [
-    {"NAME": "latest", "PYTHON_VERSION": "3.9"},
+    {"NAME": "latest", "PYTHON_VERSION": "3.10"},
+    {"NAME": "python3.10", "PYTHON_VERSION": "3.10"},
     {"NAME": "python3.9", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7", "PYTHON_VERSION": "3.7"},
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
+    {"NAME": "python3.10-slim", "PYTHON_VERSION": "3.10"},
     {"NAME": "python3.9-slim", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8-slim", "PYTHON_VERSION": "3.8"},
+    {"NAME": "python3.10-alpine3.14", "PYTHON_VERSION": "3.10"},
     {"NAME": "python3.9-alpine3.14", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8-alpine3.10", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7-alpine3.8", "PYTHON_VERSION": "3.7"},


### PR DESCRIPTION
This PR should be merged *after* python 3.10 gets released around sometime this week. Until then, builds *should* fail (because until PSF releases python 3.0, the tags my PR depends on will not exist.