### PR TITLE
✨ Add support for Python 3.10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,8 @@ jobs:
           - name: python3.6
             python_version: "3.6"
           - name: python3.10-slim
-            python_version: "3.9"
-          - name: python3.10-slim
+            python_version: "3.10"
+          - name: python3.9-slim
             python_version: "3.9"
           - name: python3.8-slim
             python_version: "3.8"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         image:
           - name: latest
-            python_version: "3.9"
+            python_version: "3.10"
+          - name: python3.10
+            python_version: "3.10"
           - name: python3.9
             python_version: "3.9"
           - name: python3.8
@@ -20,7 +22,9 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
-          - name: python3.9-slim
+          - name: python3.10-slim
+            python_version: "3.9"
+          - name: python3.10-slim
             python_version: "3.9"
           - name: python3.8-slim
             python_version: "3.8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         image:
           - name: latest
-            python_version: "3.9"
+            python_version: "3.10"
+          - name: python3.10
+            python_version: "3.10"
           - name: python3.9
             python_version: "3.9"
           - name: python3.8
@@ -20,6 +22,8 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
+          - name: python3.10-slim
+            python_version: "3.10"
           - name: python3.9-slim
             python_version: "3.9"
           - name: python3.8-slim

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-* [`python3.9`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.9.dockerfile)
+* [`python3.10`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.10.dockerfile)
+* [`python3.9`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.9.dockerfile)
 * [`python3.8`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.8.dockerfile)
 * [`python3.7`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.7.dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.6.dockerfile)
+* [`python3.10-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.10-slim.dockerfile)
 * [`python3.9-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.9-slim.dockerfile)
 * [`python3.8-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.8-slim.dockerfile)
 
@@ -142,7 +144,7 @@ You can use this image as a base image for other images.
 Assuming you have a file `requirements.txt`, you could have a `Dockerfile` like this:
 
 ```Dockerfile
-FROM tiangolo/uvicorn-gunicorn:python3.9
+FROM tiangolo/uvicorn-gunicorn:python3.10
 
 COPY ./requirements.txt /app/requirements.txt
 
@@ -200,7 +202,7 @@ COPY ./pyproject.toml ./poetry.lock* /tmp/
 
 RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
 
-FROM tiangolo/uvicorn-gunicorn:python3.9
+FROM tiangolo/uvicorn-gunicorn:python3.10
 
 COPY --from=requirements-stage /tmp/requirements.txt /app/requirements.txt
 

--- a/docker-images/python3.10-slim.dockerfile
+++ b/docker-images/python3.10-slim.dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.10-slim
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]

--- a/docker-images/python3.10.dockerfile
+++ b/docker-images/python3.10.dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.10
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./gunicorn_conf.py /gunicorn_conf.py
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+
+COPY ./app /app
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Uvicorn
+CMD ["/start.sh"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ use_tag="tiangolo/uvicorn-gunicorn:$NAME"
 DOCKERFILE="$NAME"
 
 if [ "$NAME" == "latest" ] ; then
-    DOCKERFILE="python3.9"
+    DOCKERFILE="python3.10"
 fi
 
 docker build -t "$use_tag" --file "./docker-images/${DOCKERFILE}.dockerfile" "./docker-images/"

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -3,11 +3,13 @@ import subprocess
 import sys
 
 environments = [
-    {"NAME": "latest", "PYTHON_VERSION": "3.9"},
+    {"NAME": "latest", "PYTHON_VERSION": "3.10"},
+    {"NAME": "python3.10", "PYTHON_VERSION": "3.10"},
     {"NAME": "python3.9", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7", "PYTHON_VERSION": "3.7"},
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
+    {"NAME": "python3.10-slim", "PYTHON_VERSION": "3.10"},
     {"NAME": "python3.9-slim", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8-slim", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.9-alpine3.14", "PYTHON_VERSION": "3.9"},


### PR DESCRIPTION
✨ Add support for Python 3.10

This will have to wait until Uvicorn requires httptools `0.3.0` with support for Python 3.10 https://github.com/MagicStack/httptools/releases/tag/v0.3.0