### PR TITLE
add new environment variable to set number of theads

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,22 @@ docker run -d -p 80:80 -e WEB_CONCURRENCY="2" myimage
 
 This would make the image start 2 worker processes, independent of how many CPU cores are available in the server.
 
+#### `THREADS`
+
+Override the automatic definition of number of threads.
+
+By default:
+
+* 1
+
+You can set it like:
+
+```bash
+docker run -d -p 80:80 -e THREADS="4" myimage
+```
+
+This would make the image start 4 theads for each worker
+
 #### `HOST`
 
 The "host" used by Gunicorn, the IP where Gunicorn will listen for requests.

--- a/docker-images/gunicorn_conf.py
+++ b/docker-images/gunicorn_conf.py
@@ -9,6 +9,9 @@ if max_workers_str:
     use_max_workers = int(max_workers_str)
 web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
 
+threads_default = 1
+threads_str = os.getenv("THREADS", None)
+
 host = os.getenv("HOST", "0.0.0.0")
 port = os.getenv("PORT", "80")
 bind_env = os.getenv("BIND", None)
@@ -28,6 +31,13 @@ else:
     web_concurrency = max(int(default_web_concurrency), 2)
     if use_max_workers:
         web_concurrency = min(web_concurrency, use_max_workers)
+
+if threads_str:
+    threads = int(threads_str)
+    assert threads > 0
+else:
+    threads = threads_default
+
 accesslog_var = os.getenv("ACCESS_LOG", "-")
 use_accesslog = accesslog_var or None
 errorlog_var = os.getenv("ERROR_LOG", "-")


### PR DESCRIPTION
Sometimes I needed to set number of threads instead of setting extra command line arguments it's better to have this option for threads to set it as another environment variable. ;) 