### PR TITLE
⬆️ Upgrade Uvicorn to the last version supporting Python 3.6

### DIFF
--- a/docker-images/requirements.txt
+++ b/docker-images/requirements.txt
@@ -1,2 +1,2 @@
-uvicorn[standard]==0.15.0
+uvicorn[standard]==0.16.0
 gunicorn==20.1.0


### PR DESCRIPTION
⬆️ Upgrade Uvicorn to the last version supporting Python 3.6

After this, I'll deprecate/remove Python 3.6 and upgrade to the latest version.