### PR TITLE
✨ Live-Reload: Support uvicorn option "no access log"

### DIFF
--- a/docker-images/start-reload.sh
+++ b/docker-images/start-reload.sh
@@ -13,6 +13,9 @@ export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
 HOST=${HOST:-0.0.0.0}
 PORT=${PORT:-80}
 LOG_LEVEL=${LOG_LEVEL:-info}
+ACCESS_LOG=${ACCESS_LOG-"-"}   # Set ACCESS_LOG="-" only if unset
+
+# If ACCESS_LOG was set and is null, disable access log
 ACCESS_LOG_OPTION=""
 if [ -z "$ACCESS_LOG" ] ; then
     ACCESS_LOG_OPTION="--no-access-log"

--- a/docker-images/start-reload.sh
+++ b/docker-images/start-reload.sh
@@ -13,6 +13,10 @@ export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
 HOST=${HOST:-0.0.0.0}
 PORT=${PORT:-80}
 LOG_LEVEL=${LOG_LEVEL:-info}
+ACCESS_LOG_OPTION=""
+if [ -z "$ACCESS_LOG" ] ; then
+    ACCESS_LOG_OPTION="--no-access-log"
+fi
 
 # If there's a prestart.sh script in the /app directory or other path specified, run it before starting
 PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
@@ -25,4 +29,4 @@ else
 fi
 
 # Start Uvicorn with live reload
-exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE"
+exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL $ACCESS_LOG_OPTION "$APP_MODULE"

--- a/tests/test_03_reload/test_env_vars_1.py
+++ b/tests/test_03_reload/test_env_vars_1.py
@@ -7,6 +7,7 @@ from docker.client import DockerClient
 
 from ..utils import (
     CONTAINER_NAME,
+    get_config,
     get_logs,
     get_response_text1,
     remove_previous_container,
@@ -25,6 +26,8 @@ def verify_container(container: DockerClient, response_text: str) -> None:
     assert "Uvicorn running on http://0.0.0.0:80" in logs
     response = requests.get("http://127.0.0.1:8000")
     assert response.text == response_text
+    config_data = get_config(container)
+    assert config_data["accesslog"] == "-"
 
 
 def test_env_vars_1() -> None:

--- a/tests/test_03_reload/test_env_vars_1.py
+++ b/tests/test_03_reload/test_env_vars_1.py
@@ -7,7 +7,7 @@ from docker.client import DockerClient
 
 from ..utils import (
     CONTAINER_NAME,
-    get_config,
+    get_process_names,
     get_logs,
     get_response_text1,
     remove_previous_container,
@@ -26,8 +26,8 @@ def verify_container(container: DockerClient, response_text: str) -> None:
     assert "Uvicorn running on http://0.0.0.0:80" in logs
     response = requests.get("http://127.0.0.1:8000")
     assert response.text == response_text
-    config_data = get_config(container)
-    assert config_data["accesslog"] == "-"
+    uvicorn_cmd = get_process_names(container, name="uvicorn")[0]
+    assert "--no-access-log" not in uvicorn_cmd
 
 
 def test_env_vars_1() -> None:

--- a/tests/test_03_reload/test_env_vars_2.py
+++ b/tests/test_03_reload/test_env_vars_2.py
@@ -4,7 +4,7 @@ import time
 import docker
 from docker.models.containers import Container
 
-from ..utils import CONTAINER_NAME, get_config, get_logs, remove_previous_container
+from ..utils import CONTAINER_NAME, get_process_names, get_logs, remove_previous_container
 
 client = docker.from_env()
 
@@ -17,8 +17,8 @@ def verify_container(container: Container) -> None:
         "Running inside /app/prestart.sh, you could add migrations to this file" in logs
     )
     assert "Uvicorn running on http://127.0.0.1:80" in logs
-    config_data = get_config(container)
-    assert config_data["accesslog"] is None
+    uvicorn_cmd = get_process_names(container, name="uvicorn")[0]
+    assert "--no-access-log" in uvicorn_cmd
 
 
 def test_env_vars_2() -> None:

--- a/tests/test_03_reload/test_env_vars_2.py
+++ b/tests/test_03_reload/test_env_vars_2.py
@@ -4,7 +4,7 @@ import time
 import docker
 from docker.models.containers import Container
 
-from ..utils import CONTAINER_NAME, get_logs, remove_previous_container
+from ..utils import CONTAINER_NAME, get_config, get_logs, remove_previous_container
 
 client = docker.from_env()
 
@@ -17,6 +17,8 @@ def verify_container(container: Container) -> None:
         "Running inside /app/prestart.sh, you could add migrations to this file" in logs
     )
     assert "Uvicorn running on http://127.0.0.1:80" in logs
+    config_data = get_config(container)
+    assert config_data["accesslog"] is None
 
 
 def test_env_vars_2() -> None:
@@ -28,7 +30,7 @@ def test_env_vars_2() -> None:
     container = client.containers.run(
         image,
         name=CONTAINER_NAME,
-        environment={"HOST": "127.0.0.1"},
+        environment={"HOST": "127.0.0.1", "ACCESS_LOG": ""},
         ports={"80": "8000"},
         detach=True,
         command="/start-reload.sh",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,11 +10,11 @@ CONTAINER_NAME = "uvicorn-gunicorn-test"
 IMAGE_NAME = "uvicorn-gunicorn-testimage"
 
 
-def get_process_names(container: Container) -> List[str]:
+def get_process_names(container: Container, name: str = "gunicorn") -> List[str]:
     top = container.top()
     process_commands = [p[7] for p in top["Processes"]]
-    gunicorn_processes = [p for p in process_commands if "gunicorn" in p]
-    return gunicorn_processes
+    processes = [p for p in process_commands if name in p]
+    return processes
 
 
 def get_gunicorn_conf_path(container: Container) -> str:


### PR DESCRIPTION
Implements #177 

This MR adds the feature of disabling the uvicorn access log while using live-reload via `start-reload.sh`. Specifically, the option `--no-access-log` is passed to to uvicorn if `ACCESS_LOG` is set to an empty value.